### PR TITLE
Remove `options.filename` from `css.stringify`

### DIFF
--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -22,9 +22,8 @@ module.exports = mixin;
  */
 
 function mixin(compiler) {
-  var file = compiler.options.filename || 'generated.css';
   compiler._comment = compiler.comment;
-  compiler.map = new SourceMap({ file: file });
+  compiler.map = new SourceMap();
   compiler.position = { line: 1, column: 1 };
   compiler.files = {};
   for (var k in exports) compiler[k] = exports[k];


### PR DESCRIPTION
Why?
- It is only used to set the `file` property of the source map, and
  that’s probably done just because the `file` property used to be a
  required property of source maps. It isn’t no more.
- The `file` property is not used by browsers.
- The user could easily just add the property himself on the returned
  source map object.
- It was neither documented nor tested.
- KISS.

@conradz:

> I think if we decide to deprecate filename, we can just remove it
> altogether and bump major version.

https://github.com/reworkcss/css-stringify/pull/42#issuecomment-44884423
