### PR TITLE
Make relative applied source paths relative to CWD

### DIFF
--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -6,7 +6,9 @@
 var SourceMap = require('source-map').SourceMapGenerator;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var sourceMapResolve = require('source-map-resolve');
+var urix = require('urix');
 var fs = require('fs');
+var path = require('path');
 
 /**
  * Expose `mixin()`.
@@ -55,7 +57,7 @@ exports.updatePosition = function(str) {
  */
 
 exports.emit = function(str, pos, startOnly) {
-  var sourceFile = pos && pos.source || 'source.css';
+  var sourceFile = urix(pos && pos.source || 'source.css');
 
   if (pos && pos.start) {
     this.map.addMapping({
@@ -120,8 +122,9 @@ exports.applySourceMaps = function() {
     var originalMap = sourceMapResolve.resolveSync(
       content, file, fs.readFileSync);
     if (originalMap) {
-      originalMap = new SourceMapConsumer(originalMap.map);
-      this.map.applySourceMap(originalMap, file);
+      var map = new SourceMapConsumer(originalMap.map);
+      var relativeTo = originalMap.sourcesRelativeTo;
+      this.map.applySourceMap(map, file, urix(path.dirname(relativeTo)));
     }
   }, this);
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "dependencies": {
     "source-map": "~0.1.31",
-    "source-map-resolve": "^0.1.3"
+    "source-map-resolve": "^0.1.3",
+    "urix": "~0.1.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/stringify/css-stringify.js
+++ b/test/stringify/css-stringify.js
@@ -71,7 +71,7 @@ describe('stringify(obj, {sourcemap: true})', function(){
     map.sourceContentFor(file).should.eql(src);
   });
 
-  it('should apply included source maps', function(){
+  it('should apply included source maps, with paths adjusted to CWD', function(){
     var file = 'test/stringify/source-map-apply.css';
     var src = read(file, 'utf8');
     var stylesheet = parse(src, { source: file, position: true });
@@ -84,14 +84,28 @@ describe('stringify(obj, {sourcemap: true})', function(){
       column: 0,
       line: 1,
       name: null,
-      source: 'source-map-apply.scss'
+      source: 'test/stringify/source-map-apply.scss'
     });
 
     map.originalPositionFor({ line: 2, column: 2 }).should.eql({
       column: 7,
       line: 1,
       name: null,
-      source: 'source-map-apply.scss'
+      source: 'test/stringify/source-map-apply.scss'
     });
+  });
+
+  it('should convert Windows-style paths to URLs', function(){
+    var originalSep = path.sep;
+    path.sep = '\\'; // Pretend we’re on Windows (if we aren’t already).
+
+    var src = 'C:\\test\\source.css';
+    var css = 'a { color: black; }'
+    var stylesheet = parse(css, {source: src, position: true});
+    var result = stringify(stylesheet, {sourcemap: true});
+
+    result.map.sources.should.eql(['/test/source.css']);
+
+    path.sep = originalSep;
   });
 });


### PR DESCRIPTION
When generating a source map, the paths put into the `sources` array of
the source map normally come from `pos.source` properties on the AST
nodes. These are today assumed to be relative to the current working
directory, since that’s how any original source maps are resolved and
applied.

Paths in the `sources` array can also come from applied original maps.
Relative such source paths are relative to the original source map --
not to the current working directory!

It does not make sense to mix paths that are relative to different
things. Therefore this commit makes sure that applied relative source
maps are rewritten to be relative to the current working directory, like
all other sources.

An existing test was updated to test this.

The fix uses the third parameter of the `.applySourceMap()` method,
which must be a URL -- a Windows-style path does not cut it. While the
applied source paths should already be URLs (since they come from a
source map, which should be used in browsers), we call `path.dirname()`
on them, which returns Windows-style paths on Windows. Therefore `urix`
is used to convert them back to URLs again.

For consistency, I then went ahead and fixed another issue: Before
adding any sources into the source map, we should convert them to URLs
if they are Windows-style paths. That is as easy as calling `urix` on
each source first. A test has been added for this.
