### PR TITLE
Add non-enumerable parent reference to each node. Fixes #19

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,6 +78,7 @@ the node.
 - source: `String` or `undefined`. The value of `options.source` if passed to
   `css.parse`. Otherwise `undefined`.
 - content: `String`. The full source string passed to `css.parse`.
+- parent: `Object`. Reference to the parent node that contains this node.
 
 The line and column numbers are 1-based: The first line is 1 and the first
 column of a line is 1 (not 0).

--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -554,7 +554,7 @@ module.exports = function(css, options){
     });
   }
 
-  return stylesheet();
+  return addParent(stylesheet());
 };
 
 /**
@@ -563,4 +563,33 @@ module.exports = function(css, options){
 
 function trim(str) {
   return str ? str.replace(/^\s+|\s+$/g, '') : '';
+}
+
+/**
+ * Adds non-enumerable parent node reference to each node.
+ */
+
+function addParent(obj, parent) {
+  var isNode = obj && typeof obj.type === 'string';
+  var childParent = isNode ? obj : parent;
+
+  for (var k in obj) {
+    var value = obj[k];
+    if (Array.isArray(value)) {
+      value.forEach(function(v) { addParent(v, childParent); });
+    } else if (value && typeof value === 'object') {
+      addParent(value, childParent);
+    }
+  }
+
+  if (isNode) {
+    Object.defineProperty(obj, 'parent', {
+      configurable: true,
+      writable: true,
+      enumerable: false,
+      value: parent || null
+    });
+  }
+
+  return obj;
 }

--- a/test/parse/css-parse.js
+++ b/test/parse/css-parse.js
@@ -76,4 +76,33 @@ describe('parse(str)', function(){
     });
   });
 
+  it('should set parent property', function() {
+    var result = parse(
+      'thing { test: value; }\n' +
+      '@media (min-width: 100px) { thing { test: value; } }');
+
+    assert.equal(result.parent, null);
+
+    var rules = result.stylesheet.rules;
+    assert.equal(rules.length, 2);
+
+    var rule = rules[0];
+    assert.equal(rule.parent, result);
+    assert.equal(rule.declarations.length, 1);
+
+    var decl = rule.declarations[0];
+    assert.equal(decl.parent, rule);
+
+    var media = rules[1];
+    assert.equal(media.parent, result);
+    assert.equal(media.rules.length, 1);
+
+    rule = media.rules[0];
+    assert.equal(rule.parent, media);
+
+    assert.equal(rule.declarations.length, 1);
+    decl = rule.declarations[0];
+    assert.equal(decl.parent, rule);
+  });
+
 });


### PR DESCRIPTION
This is kinda a hack, not sure if it is a good idea or not. Basically this scans through the whole AST, looking for nodes that have the `type` property set, and adding a non-enumerable `parent` property to the node. This is done after the whole AST is parsed, so it doesn't do any good for things like errors that required tracking the parent as it is parsing.

Also, not sure if it is a good idea to simply traverse all the keys of the AST.

Basically this is a very simple solution, but might not be the best. Feedback needed.
