### PR TITLE
Switch to tilde version range for source-map-resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "source-map": "~0.1.31",
-    "source-map-resolve": "^0.1.3",
+    "source-map-resolve": "~0.1.3",
     "urix": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It is 0.x and may introduce backwards-incompatible changes in minor
version increments.
