### PR TITLE
Remove the `position` option of `css.parse`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,11 +25,6 @@ Accepts a CSS string and returns an AST `object`.
 - `silent` - silently fail on parse errors.
 - `source` - the path to the file containing `css`. Makes errors and source
   maps more helpful, by letting them know where code comes from.
-- `position` - record the line and column of the start and end of nodes.
-  Required for source map generation. `true` by default.
-
-For the `source` and `position` options, also see the parse tree
-[examples](#examples) below.
 
 ### css.stringify(object, [options])
 
@@ -38,9 +33,8 @@ Accepts an AST `object` (as `css.parse` produces) and returns a CSS string.
 `options`:
 
 - `compress` - omit comments and extraneous whitespace.
-- `sourcemap` - return a sourcemap along with the CSS output (requires the
-  `position` option of `css.parse`, and its `source` option is strongly
-  recommended).
+- `sourcemap` - return a sourcemap along with the CSS output. Using the `source`
+  option of `css.parse` is strongly recommended when creating a source map.
 
 ```js
 var ast = css.parse('body { font-size: 12px; }', { position: true, source: 'source.css' });
@@ -76,36 +70,6 @@ body {
 ```
 
 Parse tree:
-
-```json
-{
-  "type": "stylesheet",
-  "stylesheet": {
-    "rules": [
-      {
-        "type": "rule",
-        "selectors": [
-          "body"
-        ],
-        "declarations": [
-          {
-            "type": "declaration",
-            "property": "background",
-            "value": "#eee"
-          },
-          {
-            "type": "declaration",
-            "property": "color",
-            "value": "#888"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Parse tree with the `position` option enabled:
 
 ```json
 {

--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -4,7 +4,6 @@ var commentre = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g
 
 module.exports = function(css, options){
   options = options || {};
-  options.position = options.position === false ? false : true;
 
   /**
    * Positional.
@@ -30,8 +29,6 @@ module.exports = function(css, options){
 
   function position() {
     var start = { line: lineno, column: column };
-    if (!options.position) return positionNoop;
-
     return function(node){
       node.position = new Position(start);
       whitespace();
@@ -54,15 +51,6 @@ module.exports = function(css, options){
    */
 
   Position.prototype.content = css;
-
-  /**
-   * Return `node`.
-   */
-
-  function positionNoop(node) {
-    whitespace();
-    return node;
-  }
 
   /**
    * Error `msg`.

--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -49,15 +49,15 @@ exports.updatePosition = function(str) {
  * Emit `str`.
  *
  * @param {String} str
- * @param {Number} [pos]
+ * @param {Object} [pos]
  * @return {String}
  * @api private
  */
 
 exports.emit = function(str, pos) {
-  var sourceFile = urix(pos && pos.source || 'source.css');
+  if (pos) {
+    var sourceFile = urix(pos.source || 'source.css');
 
-  if (pos && pos.start) {
     this.map.addMapping({
       source: sourceFile,
       generated: {

--- a/test/stringify/css-stringify.js
+++ b/test/stringify/css-stringify.js
@@ -30,7 +30,7 @@ describe('stringify(obj)', function(){
 describe('stringify(obj, {sourcemap: true})', function(){
   var file = 'test/stringify/source-map-case.css';
   var src = read(file, 'utf8');
-  var stylesheet = parse(src, { source: file, position: true });
+  var stylesheet = parse(src, { source: file });
   function loc(line, column) {
     return { line: line, column: column, source: file, name: null };
   }
@@ -74,7 +74,7 @@ describe('stringify(obj, {sourcemap: true})', function(){
   it('should apply included source maps, with paths adjusted to CWD', function(){
     var file = 'test/stringify/source-map-apply.css';
     var src = read(file, 'utf8');
-    var stylesheet = parse(src, { source: file, position: true });
+    var stylesheet = parse(src, { source: file });
     var result = stringify(stylesheet, { sourcemap: true });
     result.should.have.property('code');
     result.should.have.property('map');
@@ -101,8 +101,8 @@ describe('stringify(obj, {sourcemap: true})', function(){
 
     var src = 'C:\\test\\source.css';
     var css = 'a { color: black; }'
-    var stylesheet = parse(css, {source: src, position: true});
-    var result = stringify(stylesheet, {sourcemap: true});
+    var stylesheet = parse(css, { source: src });
+    var result = stringify(stylesheet, { sourcemap: true });
 
     result.map.sources.should.eql(['/test/source.css']);
 


### PR DESCRIPTION
It was enabled by default, makes errors and source maps more helpful,
and there’s no reason to ever turn it off, so it’s better to simply
remove it.
