### PR TITLE
Use util.inherits instead of .prototype.__proto__

### DIFF
--- a/lib/stringify/compress.js
+++ b/lib/stringify/compress.js
@@ -4,7 +4,7 @@
  */
 
 var Base = require('./compiler');
-var util = require("util");
+var inherits = require("inherits");
 
 /**
  * Expose compiler.
@@ -24,7 +24,7 @@ function Compiler(options) {
  * Inherit from `Base.prototype`.
  */
 
-util.inherits(Compiler, Base);
+inherits(Compiler, Base);
 
 /**
  * Compile `node`.

--- a/lib/stringify/identity.js
+++ b/lib/stringify/identity.js
@@ -4,7 +4,7 @@
  */
 
 var Base = require('./compiler');
-var util = require("util");
+var inherits = require("inherits");
 
 /**
  * Expose compiler.
@@ -26,7 +26,7 @@ function Compiler(options) {
  * Inherit from `Base.prototype`.
  */
 
-util.inherits(Compiler, Base);
+inherits(Compiler, Base);
 
 /**
  * Compile `node`.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "mocha": "*",
     "should": "*",
     "matcha": "~0.4.0",
-    "bytes": "~0.2.1"
+    "bytes": "~0.2.1",
+    "inherits": "^2.0.1"
   },
   "scripts": {
     "benchmark": "matcha",


### PR DESCRIPTION
If I use stringify on internet explorer via browserify,
this.mapVisit is inaccessible via `__proto__`.

util.inherits fixes it, and it doesn't hurt to use
util.inherits on node.js.
