### PR TITLE
Add option to disable processing input source maps (fixes #39)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,10 @@ Accepts an AST `object` (as `css.parse` produces) and returns a CSS string.
 - compress: omit comments and extraneous whitespace.
 - sourcemap: return a sourcemap along with the CSS output. Using the `source`
   option of `css.parse` is strongly recommended when creating a source map.
+- inputSourcemaps: (enabled by default, specify `false` to disable) reads any
+  source maps referenced by the input files when generating the output source
+  map. When enabled, file system access may be required for reading the
+  referenced source maps.
 
 ### Example
 

--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -101,12 +101,14 @@ exports.applySourceMaps = function() {
     var content = this.files[file];
     this.map.setSourceContent(file, content);
 
-    var originalMap = sourceMapResolve.resolveSync(
-      content, file, fs.readFileSync);
-    if (originalMap) {
-      var map = new SourceMapConsumer(originalMap.map);
-      var relativeTo = originalMap.sourcesRelativeTo;
-      this.map.applySourceMap(map, file, urix(path.dirname(relativeTo)));
+    if (this.options.inputSourcemaps !== false) {
+      var originalMap = sourceMapResolve.resolveSync(
+        content, file, fs.readFileSync);
+      if (originalMap) {
+        var map = new SourceMapConsumer(originalMap.map);
+        var relativeTo = originalMap.sourcesRelativeTo;
+        this.map.applySourceMap(map, file, urix(path.dirname(relativeTo)));
+      }
     }
   }, this);
 };

--- a/test/stringify/css-stringify.js
+++ b/test/stringify/css-stringify.js
@@ -95,6 +95,21 @@ describe('stringify(obj, {sourcemap: true})', function(){
     });
   });
 
+  it('should not apply included source maps when inputSourcemap is false', function(){
+    var file = 'test/stringify/source-map-apply.css';
+    var src = read(file, 'utf8');
+    var stylesheet = parse(src, { source: file });
+    var result = stringify(stylesheet, { sourcemap: true, inputSourcemaps: false });
+
+    var map = new SourceMapConsumer(result.map);
+    map.originalPositionFor({ line: 1, column: 0 }).should.eql({
+      column: 0,
+      line: 1,
+      name: null,
+      source: file
+    });
+  });
+
   it('should convert Windows-style paths to URLs', function(){
     var originalSep = path.sep;
     path.sep = '\\'; // Pretend we’re on Windows (if we aren’t already).


### PR DESCRIPTION
This fixes #39, by adding an option to disable processing the source maps referenced by the input files. Specify `inputSourcemaps: false` when stringifying.
