### PR TITLE
Use inherits from npm instead of prototype.__proto__

### DIFF
--- a/lib/stringify/compress.js
+++ b/lib/stringify/compress.js
@@ -4,7 +4,7 @@
  */
 
 var Base = require('./compiler');
-var util = require("util");
+var inherits = require("inherits");
 
 /**
  * Expose compiler.
@@ -24,7 +24,7 @@ function Compiler(options) {
  * Inherit from `Base.prototype`.
  */
 
-util.inherits(Compiler, Base);
+inherits(Compiler, Base);
 
 /**
  * Compile `node`.

--- a/lib/stringify/identity.js
+++ b/lib/stringify/identity.js
@@ -4,7 +4,7 @@
  */
 
 var Base = require('./compiler');
-var util = require("util");
+var inherits = require("inherits");
 
 /**
  * Expose compiler.
@@ -26,7 +26,7 @@ function Compiler(options) {
  * Inherit from `Base.prototype`.
  */
 
-util.inherits(Compiler, Base);
+inherits(Compiler, Base);
 
 /**
  * Compile `node`.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "mocha": "*",
     "should": "*",
     "matcha": "~0.4.0",
-    "bytes": "~0.2.1"
+    "bytes": "~0.2.1",
+    "inherits": "^2.0.1"
   },
   "scripts": {
     "benchmark": "matcha",


### PR DESCRIPTION
I use browserify to use css on web browsers.

On internet explorer, `A.prototype.__proto__ = B.prototype;` leads to errors since IE can't access A's prototype.

If I use inherits module from npm, css works on IE9, IE10, chrome, firefox, and node.js without a problem.

To make css work on IE8, I have to replace ".import" with "['import']" because IE8 uses EcmaScript 3 engine in which "import" and "catch" are researved words and can't be used directly as object properties.
Thus, IE8 should not be considered.
