### PR TITLE
Parser error improvements

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -62,6 +62,7 @@ module.exports = function(css, options){
     }
 
     var err = new Error(options.source + ':' + lineno + ':' + column + ': ' + msg);
+    err.reason = msg;
     err.filename = options.source;
     err.line = lineno;
     err.column = column;


### PR DESCRIPTION
This makes the following changes to parser errors:
### 1. Message format

Switch to a [gnu-style](https://www.gnu.org/prep/standards/html_node/Errors.html#Errors) format for parser error messages.*

```
filename:lineno:column: message
```

This makes it easier to diagnose the location of an error when multiple CSS files are being parsed in a build chain. There are also terminals and other tools that can parse messages formatted this way and jump to the location of the error in a text editor/IDE.

\* Note: if there's a different format that you would prefer that also includes the filename, I'd be happy to change it. I picked this format because it's fairly common.
### 2. Capture "reason"

Add the raw error message generated by the parser without filename/line/column, stored as `reason` on the Error object. This will make it easier to reformat parser error messages by consuming applications, if desired.
