### PR TITLE
Optionally return the SourceMapGenerator directly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,8 @@ Accepts an AST `object` (as `css.parse` produces) and returns a CSS string.
 - compress: omit comments and extraneous whitespace.
 - sourcemap: return a sourcemap along with the CSS output. Using the `source`
   option of `css.parse` is strongly recommended when creating a source map.
+  Specify `sourcemap: 'generator'` to return the SourceMapGenerator object
+  instead of serializing the source map.
 - inputSourcemaps: (enabled by default, specify `false` to disable) reads any
   source maps referenced by the input files when generating the output source
   map. When enabled, file system access may be required for reading the

--- a/lib/stringify/index.js
+++ b/lib/stringify/index.js
@@ -34,7 +34,12 @@ module.exports = function(node, options){
 
     var code = compiler.compile(node);
     compiler.applySourceMaps();
-    return { code: code, map: compiler.map.toJSON() };
+
+    var map = options.sourcemap === 'generator'
+      ? compiler.map
+      : compiler.map.toJSON();
+
+    return { code: code, map: map };
   }
 
   var code = compiler.compile(node);

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -3,6 +3,7 @@ var parse = require('../').parse;
 var path = require('path');
 var read = require('fs').readFileSync;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
 
 describe('stringify(obj, {sourcemap: true})', function() {
   var file = 'test/source-map/test.css';
@@ -99,5 +100,13 @@ describe('stringify(obj, {sourcemap: true})', function() {
     result.map.sources.should.eql(['/test/source.css']);
 
     path.sep = originalSep;
+  });
+
+  it('should return source map generator when sourcemap: "generator"', function(){
+    var css = 'a { color: black; }';
+    var stylesheet = parse(css);
+    var result = stringify(stylesheet, { sourcemap: 'generator' });
+
+    result.map.should.be.an.instanceOf(SourceMapGenerator);
   });
 });


### PR DESCRIPTION
Returns the SourceMapGenerator object without serializing to JSON when `sourcemap: 'generator'` is specified. Closes #41.
