### PR TITLE
Add @font-face messed test case and update parsing

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -461,7 +461,7 @@ module.exports = function(css, options){
 
   function atfontface() {
     var pos = position();
-    var m = match(/^@font-face */);
+    var m = match(/^@font-face\s*/);
     if (!m) return;
 
     if (!open()) return error("@font-face missing '{'");

--- a/test/cases/font-face-messed/ast.json
+++ b/test/cases/font-face-messed/ast.json
@@ -1,0 +1,90 @@
+{
+  "type": "stylesheet",
+  "stylesheet": {
+    "rules": [
+      {
+        "type": "font-face",
+        "declarations": [
+          {
+            "type": "declaration",
+            "property": "font-family",
+            "value": "\"Bitstream Vera Serif Bold\"",
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 43
+              },
+              "source": "input.css"
+            }
+          },
+          {
+            "type": "declaration",
+            "property": "src",
+            "value": "url(\"http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf\")",
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 78
+              },
+              "source": "input.css"
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 2
+          },
+          "source": "input.css"
+        }
+      },
+      {
+        "type": "rule",
+        "selectors": [
+          "body"
+        ],
+        "declarations": [
+          {
+            "type": "declaration",
+            "property": "font-family",
+            "value": "\"Bitstream Vera Serif Bold\", serif",
+            "position": {
+              "start": {
+                "line": 9,
+                "column": 3
+              },
+              "end": {
+                "line": 9,
+                "column": 50
+              },
+              "source": "input.css"
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 8,
+            "column": 1
+          },
+          "end": {
+            "line": 10,
+            "column": 2
+          },
+          "source": "input.css"
+        }
+      }
+    ]
+  }
+}

--- a/test/cases/font-face-messed/compressed.css
+++ b/test/cases/font-face-messed/compressed.css
@@ -1,0 +1,1 @@
+@font-face{font-family:"Bitstream Vera Serif Bold";src:url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");}body{font-family:"Bitstream Vera Serif Bold", serif;}

--- a/test/cases/font-face-messed/input.css
+++ b/test/cases/font-face-messed/input.css
@@ -1,0 +1,10 @@
+@font-face
+  
+       {
+  font-family: "Bitstream Vera Serif Bold";
+  src: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");
+}
+
+body {
+  font-family: "Bitstream Vera Serif Bold", serif;
+}

--- a/test/cases/font-face-messed/output.css
+++ b/test/cases/font-face-messed/output.css
@@ -1,0 +1,8 @@
+@font-face {
+  font-family: "Bitstream Vera Serif Bold";
+  src: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");
+}
+
+body {
+  font-family: "Bitstream Vera Serif Bold", serif;
+}


### PR DESCRIPTION
I was using a rework based preprocessor, and recently it wouldn't let me place my braces on the next line for the `@font-face` rule so I have updated the parsing with an accompanying test case.
