### PR TITLE
Allowed new lines between @keyframes and its name

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -283,7 +283,7 @@ module.exports = function(css, options){
 
   function atkeyframes() {
     var pos = position();
-    var m = match(/^@([-\w]+)?keyframes */);
+    var m = match(/^@([-\w]+)?keyframes\s*/);
 
     if (!m) return;
     var vendor = m[1];


### PR DESCRIPTION
Following https://github.com/reworkcss/css/commit/46d2b22aa43697ae78bd829f2770895b7da6883e, I changed a whitespace to \s.

This fixed https://github.com/reworkcss/css/issues/61.