### PR TITLE
Bugfix: convert variable to string if buffer

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -6,6 +6,12 @@ module.exports = function(css, options){
   options = options || {};
 
   /**
+   * Seen css is sometimes a buffer
+   */
+  if (css instanceof Buffer)
+    css = css.toString();
+
+  /**
    * Positional.
    */
 


### PR DESCRIPTION
Hello,

I found a little "random" bug in a package that use css as a dependency : sometimes the `css` variable in `lib/parse/index.js` is a buffer.
I actually use Node 4.2.1, this bug appeared since I upgraded from 0.12.7 to 4.1 (so I imagine that Node 4.0 broke something).

The module which use your package seems to work since I applied this fix, so if you include this 6 lines it would be great.

Thanks in advance!
Best regards,
Samuel D.

PS : sorry for my english (I imagine you hear/read this a lot)
