### PR TITLE
Fix parsing declarations that have comments with {} in them

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -228,7 +228,7 @@ module.exports = function(css, options){
     var ret = pos({
       type: 'declaration',
       property: prop.replace(commentre, ''),
-      value: val ? trim(val[0]).replace(commentre, '') : ''
+      value: val ? trim(val[0].replace(commentre, '')) : ''
     });
 
     // ;

--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -223,7 +223,7 @@ module.exports = function(css, options){
     if (!match(/^:\s*/)) return error("property missing ':'");
 
     // val
-    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)/);
+    var val = match(/^((?:\/\*.*?\*\/|'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)/);
 
     var ret = pos({
       type: 'declaration',

--- a/test/cases/comment-in-with-brackets/ast.json
+++ b/test/cases/comment-in-with-brackets/ast.json
@@ -1,0 +1,91 @@
+{
+    "type": "stylesheet",
+    "stylesheet": {
+        "parsingErrors": [],
+        "rules": [
+            {
+                "declarations": [
+                    {
+                        "position": {
+                            "end": {
+                                "column": 20,
+                                "line": 2
+                            },
+                            "source": "input.css",
+                            "start": {
+                                "column": 5,
+                                "line": 2
+                            }
+                        },
+                        "property": "color",
+                        "type": "declaration",
+                        "value": "12px"
+                    },
+                    {
+                        "position": {
+                            "end": {
+                                "column": 67,
+                                "line": 3
+                            },
+                            "source": "input.css",
+                            "start": {
+                                "column": 5,
+                                "line": 3
+                            }
+                        },
+                        "property": "padding",
+                        "type": "declaration",
+                        "value": "1px  2px  3px"
+                    },
+                    {
+                        "position": {
+                            "end": {
+                                "column": 24,
+                                "line": 4
+                            },
+                            "source": "input.css",
+                            "start": {
+                                "column": 5,
+                                "line": 4
+                            }
+                        },
+                        "property": "border",
+                        "type": "declaration",
+                        "value": "solid"
+                    },
+                    {
+                        "position": {
+                            "end": {
+                                "column": 50,
+                                "line": 4
+                            },
+                            "source": "input.css",
+                            "start": {
+                                "column": 26,
+                                "line": 4
+                            }
+                        },
+                        "property": "border-top",
+                        "type": "declaration",
+                        "value": "none\\9"
+                    }
+                ],
+                "position": {
+                    "end": {
+                        "column": 2,
+                        "line": 5
+                    },
+                    "source": "input.css",
+                    "start": {
+                        "column": 1,
+                        "line": 1
+                    }
+                },
+                "selectors": [
+                    "a"
+                ],
+                "type": "rule"
+            }
+        ]
+    }
+}

--- a/test/cases/comment-in-with-brackets/compressed.css
+++ b/test/cases/comment-in-with-brackets/compressed.css
@@ -1,0 +1,1 @@
+a{color:12px;padding:1px  2px  3px;border:solid;border-top:none\9;}

--- a/test/cases/comment-in-with-brackets/input.css
+++ b/test/cases/comment-in-with-brackets/input.css
@@ -1,0 +1,5 @@
+a {
+    color/**/: 12px;
+    padding/*4815162342*/: 1px /**/ 2px /*13*/ 3px /*{bracketed}*/;
+    border/*\**/: solid; border-top/*\**/: none\9;
+}

--- a/test/cases/comment-in-with-brackets/output.css
+++ b/test/cases/comment-in-with-brackets/output.css
@@ -1,0 +1,6 @@
+a {
+  color: 12px;
+  padding: 1px  2px  3px;
+  border: solid;
+  border-top: none\9;
+}


### PR DESCRIPTION
Some libraries (different versions of jquery-ui and jquerymobile is what I've seen) like to put descriptions inside of brackets inside of comments which breaks the parser. 

This is a slight tweak to the declaration parsing regex to make it swallow up comments with brackets and not consider the commented closing bracket as the close of the block. 
