### PR TITLE
include optional source on returned stylesheet object (fixes #85)

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -83,6 +83,7 @@ module.exports = function(css, options){
     return {
       type: 'stylesheet',
       stylesheet: {
+        source: options.source,
         rules: rulesList,
         parsingErrors: errorsList
       }

--- a/test/parse.js
+++ b/test/parse.js
@@ -8,6 +8,8 @@ describe('parse(str)', function() {
       source: 'booty.css'
     });
 
+    ast.stylesheet.source.should.equal('booty.css');
+
     var position = ast.stylesheet.rules[0].position;
     position.start.should.be.ok;
     position.end.should.be.ok;
@@ -53,7 +55,7 @@ describe('parse(str)', function() {
   });
 
   it('should list the parsing errors and continue parsing', function() {
-    var result = parse('foo { color= red; } bar { color: blue; } baz {}} boo { display: none}', { 
+    var result = parse('foo { color= red; } bar { color: blue; } baz {}} boo { display: none}', {
       silent: true,
       source: 'foo.css'
     });


### PR DESCRIPTION
This information can be useful to some plugins (such as import) and is already being exposed on any `Position` objects, so this only puts the information in a predictable place.