### PR TITLE
ignore error css code gracefully

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -242,6 +242,27 @@ module.exports = function(css, options){
    * Parse declarations.
    */
 
+  function handleClosingMissing(subject){
+      var missingCloseCount = 1;
+      while(missingCloseCount > 0){
+          // find the next closing bracket
+          var match = /}/.exec(css);
+          if(!match)
+              return error(subject + "missing '}'");
+          // update position and css
+          var str = css.substr(0,match.index + match[0].length);
+          updatePosition(str);
+          css = css.substr(match.index + match[0].length);
+          // clean comments
+          str = str.replace(/\/\*(.|\n|\r)*?\*\//g,'');
+          // search for opening or closing brackets	  
+          var opened = (str.match(/{/g) || []).length;
+          var closed = (str.match(/}/g) || []).length;
+          // update bracket closing counter	  
+          missingCloseCount += opened - closed;
+      }
+  }
+
   function declarations() {
     var decls = [];
 
@@ -257,7 +278,8 @@ module.exports = function(css, options){
       }
     }
 
-    if (!close()) return error("missing '}'");
+    if (!close())
+        return handleClosingMissing('');
     return decls;
   }
 
@@ -309,7 +331,8 @@ module.exports = function(css, options){
       frames = frames.concat(comments());
     }
 
-    if (!close()) return error("@keyframes missing '}'");
+    if (!close())
+        return handleClosingMissing('@keyframes');
 
     return pos({
       type: 'keyframes',
@@ -334,7 +357,7 @@ module.exports = function(css, options){
 
     var style = comments().concat(rules());
 
-    if (!close()) return error("@supports missing '}'");
+    if (!close())return handleClosingMissing('@supports');
 
     return pos({
       type: 'supports',
@@ -357,7 +380,7 @@ module.exports = function(css, options){
 
     var style = comments().concat(rules());
 
-    if (!close()) return error("@host missing '}'");
+    if (!close())return handleClosingMissing('@host');
 
     return pos({
       type: 'host',
@@ -380,7 +403,7 @@ module.exports = function(css, options){
 
     var style = comments().concat(rules());
 
-    if (!close()) return error("@media missing '}'");
+    if (!close()) return handleClosingMissing("@media");
 
     return pos({
       type: 'media',
@@ -427,7 +450,7 @@ module.exports = function(css, options){
       decls = decls.concat(comments());
     }
 
-    if (!close()) return error("@page missing '}'");
+    if (!close()) return handleClosingMissing("@page");
 
     return pos({
       type: 'page',
@@ -452,7 +475,7 @@ module.exports = function(css, options){
 
     var style = comments().concat(rules());
 
-    if (!close()) return error("@document missing '}'");
+    if (!close()) return handleClosingMissing("@document");
 
     return pos({
       type: 'document',
@@ -481,7 +504,7 @@ module.exports = function(css, options){
       decls = decls.concat(comments());
     }
 
-    if (!close()) return error("@font-face missing '}'");
+    if (!close()) return handleClosingMissing("@font-face");
 
     return pos({
       type: 'font-face',


### PR DESCRIPTION
I had problem parsing CSS files which had mismatch in opening and closing brackets.
Instead of ignoring the whole scope, the parser ignored half of the scope, and returned the other half which was wrongly parsed.
This fixes does it more like a browser, completely omit the scope of the syntax error.
