### PR TITLE
use Object.assign to avoid changable options

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -3,7 +3,7 @@
 var commentre = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g
 
 module.exports = function(css, options){
-  options = options || {};
+  options = Object.assign({}, options);
 
   /**
    * Positional.

--- a/lib/stringify/compiler.js
+++ b/lib/stringify/compiler.js
@@ -14,7 +14,7 @@ module.exports = Compiler;
  */
 
 function Compiler(opts) {
-  this.options = opts || {};
+  this.options = Object.assign({}, opts);
 }
 
 /**

--- a/lib/stringify/identity.js
+++ b/lib/stringify/identity.js
@@ -17,7 +17,6 @@ module.exports = Compiler;
  */
 
 function Compiler(options) {
-  options = options || {};
   Base.call(this, options);
   this.indentation = options.indent;
 }

--- a/lib/stringify/index.js
+++ b/lib/stringify/index.js
@@ -21,7 +21,7 @@ var Identity = require('./identity');
  */
 
 module.exports = function(node, options){
-  options = options || {};
+  options = Object.assign({}, options);
 
   var compiler = options.compress
     ? new Compressed(options)


### PR DESCRIPTION
use `Object.assign` to replace the `||` operator.
