### PR TITLE
Fix parsing of property values that contain comments with braces in them

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -224,7 +224,7 @@ module.exports = function(css, options){
     if (!match(/^:\s*/)) return error("property missing ':'");
 
     // val
-    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)/);
+    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|\/\*[^*]*\*+([^/*][^*]*\*+)*\/|[^};])+)/);
 
     var ret = pos({
       type: 'declaration',

--- a/test/parse.js
+++ b/test/parse.js
@@ -105,4 +105,16 @@ describe('parse(str)', function() {
     decl.parent.should.equal(rule);
   });
 
+  it('should not throw if there is an { in a comment in a property value', function () {
+    should(function() {
+      parse('thing { color: red /* { */; } ');
+    }).not.throw();
+  });
+
+  it('should not throw if there is an } in a comment in a property value', function () {
+    should(function() {
+      parse('thing { color: red /* } */; } ');
+    }).not.throw();
+  });
+
 });


### PR DESCRIPTION
I ran into this when parsing CSS from jquery-ui, which has /* {something} */ all over the place. I don't know a better way to include the comment regex, unfortunately.

My first pull request on GitHub. Be brutal, but be nice please.