### PR TITLE
Generalize regex to support emojis

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -296,7 +296,7 @@ module.exports = function(css, options){
     var vendor = m[1];
 
     // identifier
-    var m = match(/^([-\w]+)\s*/);
+    var m = match(/^([-(\w|\uD83C-\uDBFF\uDC00-\uDFFF)*]+)\s*/);
     if (!m) return error("@keyframes missing name");
     var name = m[1];
 


### PR DESCRIPTION
In keyframe names, it's valid to use any unicode character, not just anything that matches `\w`. I changed the regex to match emoji `@keyframe` names, as well as ascii strings.

Based on [this](https://snook.ca/archives/html_and_css/unicode_for_css_class_names), there was support for this way back in '07.

I'm sure there's a more elegant regex to achieve the same goal, but it's not my strong point :/