### PR TITLE
Upgrade source-map-resolve to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "lib"
   ],
   "dependencies": {
+    "inherits": "^2.0.1",
     "source-map": "^0.1.38",
-    "source-map-resolve": "^0.3.0",
-    "urix": "^0.1.0",
-    "inherits": "^2.0.1"
+    "source-map-resolve": "^0.5.1",
+    "urix": "^0.1.0"
   },
   "devDependencies": {
     "mocha": "^1.21.3",


### PR DESCRIPTION
I know this project hasn't received much love recently, but hopefully this is a very quick fix to merge.

Snyk is currently reporting a [medium severity security vulnerability](https://snyk.io/test/npm/css?severity=high&severity=medium&severity=low) introduced by this older version of `source-map-resolve`

> **Introduced through:** css@2.2.1 › source-map-resolve@0.3.1 › atob@1.1.3
> **Remediation:** Upgrade to source-map-resolve@0.5.0.
> Affected versions of [atob](https://www.npmjs.com/package/atob) are vulnerable to Uninitialized Memory Exposure. It allocates uninitialized Buffers when a number is passed in user provided fields.

The tests still pass. Please can we get this merged so we can fix other projects that depend on this library?

Many thanks