### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "Readme.md"
   ],
   "dependencies": {
-    "inherits": "^2.0.1",
-    "source-map": "^0.1.38",
-    "source-map-resolve": "^0.5.1",
+    "inherits": "^2.0.3",
+    "source-map": "^0.6.1",
+    "source-map-resolve": "^0.5.2",
     "urix": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade package dependencies, specifically bumping `source-map` to 0.6.x - the latest version prior to a breaking API change.