### PR TITLE
Fix an error

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -166,6 +166,7 @@ module.exports = function(css, options){
 
   function comment() {
     var pos = position();
+    css = css.toString();
     if ('/' != css.charAt(0) || '*' != css.charAt(1)) return;
 
     var i = 2;


### PR DESCRIPTION
Description
(node:8504) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'slice' of undefined
    at match (C:\Users\Jim\Documents\Webstorm\bootinspect\node_modules\css\lib\parse\index.js:136:15)
    at whitespace (C:\Users\Jim\Documents\Webstorm\bootinspect\node_modules\css\lib\parse\index.js:145:5)
    at rules (C:\Users\Jim\Documents\Webstorm\bootinspect\node_modules\css\lib\parse\index.js:116:5)
    at stylesheet (C:\Users\Jim\Documents\Webstorm\bootinspect\node_modules\css\lib\parse\index.js:81:21)
    at Object.module.exports [as parse] (C:\Users\Jim\Documents\Webstorm\bootinspect\node_modules\css\lib\parse\index.js:566:20)
    at inspectFile (C:\Users\Jim\Documents\Webstorm\bootinspect\core\inspect.js:14:21)
    at <anonymous>
(node:8504) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:8504) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.