### PR TITLE
Give more context to error " property missing ':' "

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -221,8 +221,8 @@ module.exports = function(css, options){
     prop = trim(prop[0]);
 
     // :
-    if (!match(/^:\s*/)) return error("property missing ':'");
-
+    if (!match(/^:\s*/)) return error("property missing ':' in '" + prop + "' of type '" + typeof prop + "'");
+    
     // val
     var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)/);
 


### PR DESCRIPTION
This PR gives context to an error we have had a hard time to debug with `styled-component`.
This will print out the property which caused the error.