### PR TITLE
#139 error can't resolve 'fs' fix

### DIFF
--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -6,7 +6,11 @@
 var SourceMap = require('source-map').SourceMapGenerator;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var sourceMapResolve = require('source-map-resolve');
-var fs = require('fs');
+try {
+  var fs = require("fs");
+} catch (e) {
+  var fs = null;
+}
 var path = require('path');
 
 /**

--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -109,6 +109,9 @@ exports.addFile = function(file, pos) {
 
 exports.applySourceMaps = function() {
   Object.keys(this.files).forEach(function(file) {
+    if(!fs) {
+      throw Error('Module "fs" not found. Source maps not supported. This could be because you\'re running in a browser.');
+    }
     var content = this.files[file];
     this.map.setSourceContent(file, content);
 


### PR DESCRIPTION
Catch error if `fs` module not found - as when running in a browser.

This means that `parse` will work - which is all I need. Though it won't allow you to use sourcemaps!