### PR TITLE
#139 error can't resolve 'fs' fix 2 - fs getter

### DIFF
--- a/lib/stringify/getFs.js
+++ b/lib/stringify/getFs.js
@@ -1,0 +1,15 @@
+try {
+  var fs = require("fs");
+} catch (e) {
+  var fs = null;
+}
+
+module.exports = function () {
+  if (!fs) {
+    throw Error(
+      'Module "fs" not found. Source maps not supported. This could be because you\'re running in a browser.'
+    );
+  }
+
+  return fs;
+};

--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -6,7 +6,11 @@
 var SourceMap = require('source-map').SourceMapGenerator;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var sourceMapResolve = require('source-map-resolve');
-var fs = require('fs');
+try {
+  var fs = require("fs");
+} catch (e) {
+  var fs = null;
+}
 var path = require('path');
 
 /**

--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -109,6 +109,9 @@ exports.addFile = function(file, pos) {
 
 exports.applySourceMaps = function() {
   Object.keys(this.files).forEach(function(file) {
+    if(!fs) {
+      throw Error('Module "fs" not found. Source maps not supported. This could be because you\'re running in a browser.');
+    }
     var content = this.files[file];
     this.map.setSourceContent(file, content);
 

--- a/lib/stringify/source-map-support.js
+++ b/lib/stringify/source-map-support.js
@@ -6,12 +6,8 @@
 var SourceMap = require('source-map').SourceMapGenerator;
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var sourceMapResolve = require('source-map-resolve');
-try {
-  var fs = require("fs");
-} catch (e) {
-  var fs = null;
-}
 var path = require('path');
+var getFs = require('./getFs');
 
 /**
  * Expose `mixin()`.
@@ -109,15 +105,12 @@ exports.addFile = function(file, pos) {
 
 exports.applySourceMaps = function() {
   Object.keys(this.files).forEach(function(file) {
-    if(!fs) {
-      throw Error('Module "fs" not found. Source maps not supported. This could be because you\'re running in a browser.');
-    }
     var content = this.files[file];
     this.map.setSourceContent(file, content);
 
     if (this.options.inputSourcemaps !== false) {
       var originalMap = sourceMapResolve.resolveSync(
-        content, file, fs.readFileSync);
+        content, file, getFs().readFileSync);
       if (originalMap) {
         var map = new SourceMapConsumer(originalMap.map);
         var relativeTo = originalMap.sourcesRelativeTo;


### PR DESCRIPTION
Alternative way to guard against `fs` not found errors when using the module in a browser.