### PR TITLE
Stringify: allow empty string for indent option

### DIFF
--- a/lib/stringify/identity.js
+++ b/lib/stringify/identity.js
@@ -19,7 +19,7 @@ module.exports = Compiler;
 function Compiler(options) {
   options = options || {};
   Base.call(this, options);
-  this.indentation = options.indent;
+  this.indentation = typeof options.indent === 'string' ? options.indent : '  ';
 }
 
 /**
@@ -250,5 +250,5 @@ Compiler.prototype.indent = function(level) {
     return '';
   }
 
-  return Array(this.level).join(this.indentation || '  ');
+  return Array(this.level).join(this.indentation);
 };

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -110,3 +110,28 @@ describe('stringify(obj, {sourcemap: true})', function() {
     result.map.should.be.an.instanceOf(SourceMapGenerator);
   });
 });
+
+describe('stringify(obj, {indent: *})', function() {
+  var css =
+    '@media print {\n' +
+    '\tbody {\n' +
+    '\t\tbackground: #fff;\n' +
+    '\t}\n' +
+    '}';
+  var stylesheet = parse(css);
+
+  it('should default to two-space indent', function(){
+    var result = stringify(stylesheet);
+    result.should.eql(css.replace(/\t/g, '  '));
+  });
+
+  it('should indent according to the indent string', function(){
+    var result = stringify(stylesheet, { indent: '\t' });
+    result.should.eql(css);
+  });
+
+  it('should accept empty string for indent', function(){
+    var result = stringify(stylesheet, { indent: '' });
+    result.should.eql(css.replace(/\t/g, ''));
+  });
+});


### PR DESCRIPTION
In the existing implementation, empty strings used in the indent option are treated as falsy and therefore ignored in the following fallback:
https://github.com/reworkcss/css/blob/b7f3cb62dcb12f569189c38cbdb756553bf0415b/lib/stringify/identity.js#L253

This PR resolves that issue, and adds tests for behavior surrounding the indent option.